### PR TITLE
adding session token support

### DIFF
--- a/src/main/java/AWSClientFactory.java
+++ b/src/main/java/AWSClientFactory.java
@@ -64,16 +64,18 @@ public class AWSClientFactory {
     @Getter private final Integer proxyPort;
     @Getter private final String awsAccessKey;
     @Getter private final String awsSecretKey;
+    @Getter private final String awsSessionToken;
     @Getter private final String region;
 
     private String credentialsDescriptor;
     private AWSCredentialsProvider awsCredentialsProvider;
 
-    public AWSClientFactory(String credentialsType, String credentialsId, String proxyHost, String proxyPort, String awsAccessKey, String awsSecretKey,
+    public AWSClientFactory(String credentialsType, String credentialsId, String proxyHost, String proxyPort, String awsAccessKey, String awsSecretKey, String awsSessionToken,
                        String region, Run<?, ?> build) {
 
         this.awsAccessKey = Validation.sanitize(awsAccessKey);
         this.awsSecretKey = Validation.sanitize(awsSecretKey);
+        this.awsSessionToken = Validation.sanitize(awsSessionToken);
         this.region = Validation.sanitize(region);
 
         Validation.checkAWSClientFactoryRegionConfig(this.region);
@@ -106,7 +108,7 @@ public class AWSClientFactory {
                 throw new InvalidInputException(Validation.invalidCredentialsIdError);
             }
         } else if(credentialsType.equals(CredentialsType.Keys.toString())) {
-            awsCredentialsProvider = getBasicCredentialsOrDefaultChain(Validation.sanitize(awsAccessKey), Validation.sanitize(awsSecretKey));
+            awsCredentialsProvider = getBasicCredentialsOrDefaultChain(Validation.sanitize(awsAccessKey), Validation.sanitize(awsSecretKey), Validation.sanitize(awsSessionToken));
             this.proxyHost = Validation.sanitize(proxyHost);
             this.proxyPort = Validation.parseInt(proxyPort);
         } else {
@@ -130,9 +132,12 @@ public class AWSClientFactory {
         return client;
     }
 
-    public static AWSCredentialsProvider getBasicCredentialsOrDefaultChain(String accessKey, String secretKey) {
+    public static AWSCredentialsProvider getBasicCredentialsOrDefaultChain(String accessKey, String secretKey, String awsSessionToken) {
         AWSCredentialsProvider result;
-        if(StringUtils.isNotEmpty(accessKey) && StringUtils.isNotEmpty(secretKey)) {
+        if (StringUtils.isNotEmpty(accessKey) && StringUtils.isNotEmpty(secretKey) && StringUtils.isNotEmpty(awsSessionToken)) {
+            result = new AWSStaticCredentialsProvider(new BasicSessionCredentials(accessKey, secretKey, awsSessionToken));
+        }
+        else if (StringUtils.isNotEmpty(accessKey) && StringUtils.isNotEmpty(secretKey)) {
             result = new AWSStaticCredentialsProvider(new BasicAWSCredentials(accessKey, secretKey));
         } else {
             result = DefaultAWSCredentialsProviderChain.getInstance();

--- a/src/main/java/CodeBuildCredentials.java
+++ b/src/main/java/CodeBuildCredentials.java
@@ -60,6 +60,7 @@ public class CodeBuildCredentials extends BaseStandardCredentials implements AWS
     private static final int ERROR_MESSAGE_MAX_LENGTH = 178;
 
     @Getter @Setter private final String accessKey;
+    @Getter @Setter private final String sessionToken;
     @Getter @Setter private final String secretKey;
     @Getter @Setter private final String proxyHost;
     @Getter @Setter private final String proxyPort;
@@ -67,11 +68,12 @@ public class CodeBuildCredentials extends BaseStandardCredentials implements AWS
     @Getter @Setter private final String externalId;
 
     @DataBoundConstructor
-    public CodeBuildCredentials(CredentialsScope scope, String id, String description, String accessKey, String secretKey,
+    public CodeBuildCredentials(CredentialsScope scope, String id, String description, String accessKey, String secretKey, String sessionToken,
                                 String proxyHost, String proxyPort, String iamRoleArn, String externalId) {
         super(scope, id, description);
         this.accessKey = Validation.sanitize(accessKey);
         this.secretKey = Validation.sanitize(secretKey);
+        this.sessionToken = Validation.sanitize(sessionToken);
         this.proxyHost = proxyHost;
         this.proxyPort = proxyPort;
         this.iamRoleArn = Validation.sanitize(iamRoleArn);
@@ -92,7 +94,7 @@ public class CodeBuildCredentials extends BaseStandardCredentials implements AWS
 
     @Override
     public AWSCredentials getCredentials() {
-        AWSCredentialsProvider credentialsProvider = AWSClientFactory.getBasicCredentialsOrDefaultChain(accessKey, secretKey);
+        AWSCredentialsProvider credentialsProvider = AWSClientFactory.getBasicCredentialsOrDefaultChain(accessKey, secretKey, sessionToken);
         AWSCredentials initialCredentials = credentialsProvider.getCredentials();
 
         if (iamRoleArn.isEmpty()) {
@@ -131,7 +133,7 @@ public class CodeBuildCredentials extends BaseStandardCredentials implements AWS
                                                @QueryParameter("secretKey") final String secretKey) {
 
             try {
-                AWSCredentials initialCredentials = AWSClientFactory.getBasicCredentialsOrDefaultChain(accessKey, secretKey).getCredentials();
+                AWSCredentials initialCredentials = AWSClientFactory.getBasicCredentialsOrDefaultChain(accessKey, secretKey, "").getCredentials();
                 new AWSCodeBuildClient(initialCredentials, getClientConfiguration(proxyHost, proxyPort)).listProjects(new ListProjectsRequest());
 
             } catch (Exception e) {

--- a/src/main/java/CodeBuildStep.java
+++ b/src/main/java/CodeBuildStep.java
@@ -53,6 +53,7 @@ public class CodeBuildStep extends AbstractStepImpl {
     @Getter private String proxyPort;
     @Getter private String awsAccessKey;
     @Getter private String awsSecretKey;
+    @Getter private String awsSessionToken;
     @Getter private String region;
     @Getter private String projectName;
     @Getter private String sourceControlType;
@@ -98,6 +99,11 @@ public class CodeBuildStep extends AbstractStepImpl {
     @DataBoundSetter
     public void setAwsSecretKey(String awsSecretKey) {
         this.awsSecretKey = awsSecretKey;
+    }
+
+    @DataBoundSetter
+    public void setAwsSessionToken(String awsSessionToken) {
+        this.awsSessionToken = awsSessionToken;
     }
 
     @DataBoundSetter
@@ -314,7 +320,7 @@ public class CodeBuildStep extends AbstractStepImpl {
             CodeBuilder builder = new CodeBuilder(
                     step.getCredentialsType(), step.getCredentialsId(),
                     step.getProxyHost(), step.getProxyPort(),
-                    step.getAwsAccessKey(), step.getAwsSecretKey(),
+                    step.getAwsAccessKey(), step.getAwsSecretKey(), step.getAwsSessionToken(),
                     step.getRegion(), step.getProjectName(),
                     step.sourceVersion, step.sseAlgorithm, step.sourceControlType, step.gitCloneDepthOverride,
                     step.artifactTypeOverride, step.artifactLocationOverride, step.artifactNameOverride,

--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -54,6 +54,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
     @Getter private String proxyPort;
     @Getter private String awsAccessKey;
     @Getter private String awsSecretKey;
+    @Getter private String awsSessionToken;
     @Getter private String region;
     @Getter private String projectName;
     @Getter private String sourceControlType;
@@ -99,7 +100,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
 
 
     @DataBoundConstructor
-    public CodeBuilder(String credentialsType, String credentialsId, String proxyHost, String proxyPort, String awsAccessKey, String awsSecretKey,
+    public CodeBuilder(String credentialsType, String credentialsId, String proxyHost, String proxyPort, String awsAccessKey, String awsSecretKey, String awsSessionToken,
                        String region, String projectName, String sourceVersion, String sseAlgorithm, String sourceControlType, String gitCloneDepthOverride,
                        String artifactTypeOverride, String artifactLocationOverride, String artifactNameOverride,
                        String artifactNamespaceOverride, String artifactPackagingOverride, String artifactPathOverride,
@@ -111,6 +112,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
         this.proxyPort = Validation.sanitize(proxyPort);
         this.awsAccessKey = Validation.sanitize(awsAccessKey);
         this.awsSecretKey = Validation.sanitize(awsSecretKey);
+        this.awsSessionToken = Validation.sanitize(awsSessionToken);
         this.region = Validation.sanitize(region);
         this.projectName = Validation.sanitize(projectName);
         this.sourceControlType = Validation.sanitize(sourceControlType);
@@ -149,6 +151,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
                     getParameterized(this.proxyPort),
                     getParameterized(this.awsAccessKey),
                     getParameterized(this.awsSecretKey),
+                    getParameterized(this.awsSessionToken),
                     getParameterized(this.region),
                     build);
         } catch (Exception e) {

--- a/src/test/java/AWSClientFactoryTest.java
+++ b/src/test/java/AWSClientFactoryTest.java
@@ -15,6 +15,8 @@
  */
 
 import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.AWSSessionCredentials;
+import com.amazonaws.auth.BasicSessionCredentials;
 import com.amazonaws.auth.DefaultAWSCredentialsProviderChain;
 import com.amazonaws.services.codebuild.model.InvalidInputException;
 import com.cloudbees.plugins.credentials.*;
@@ -49,7 +51,7 @@ public class AWSClientFactoryTest {
     private static final String proxyPort = "2";
 
     private final CodeBuildCredentials mockCBCreds = mock(CodeBuildCredentials.class);
-    private final AWSCredentials mockAWSCreds = mock(AWSCredentials.class);
+    private final AWSSessionCredentials mockAWSCreds = mock(BasicSessionCredentials.class);
     private final DefaultAWSCredentialsProviderChain cpChain = mock(DefaultAWSCredentialsProviderChain.class);
     private final SystemCredentialsProvider mockSysCreds = mock(SystemCredentialsProvider.class);
     private final Run<?, ?> build = mock(Run.class);
@@ -67,6 +69,7 @@ public class AWSClientFactoryTest {
 
         when(mockAWSCreds.getAWSAccessKeyId()).thenReturn("a");
         when(mockAWSCreds.getAWSSecretKey()).thenReturn("s");
+        when(mockAWSCreds.getSessionToken()).thenReturn("t");
         when(SystemCredentialsProvider.getInstance()).thenReturn(mockSysCreds);
 
         when(DefaultAWSCredentialsProviderChain.getInstance()).thenReturn(cpChain);
@@ -75,7 +78,7 @@ public class AWSClientFactoryTest {
     @Test
     public void testNullInput() {
         try {
-            new AWSClientFactory(null, null, null, null, null, null, null, build);
+            new AWSClientFactory(null, null, null, null, null, null, null, null, build);
         } catch (InvalidInputException e) {
             assert(e.getMessage().contains(Validation.invalidRegionError));
         }
@@ -84,7 +87,7 @@ public class AWSClientFactoryTest {
     @Test
     public void testBlankInput() {
         try {
-            new AWSClientFactory("", "", "", "", "", "", "", build);
+            new AWSClientFactory("", "", "", "", "", "", "", "", build);
         } catch (InvalidInputException e) {
             assert(e.getMessage().contains(Validation.invalidRegionError));
         }
@@ -92,13 +95,13 @@ public class AWSClientFactoryTest {
 
     @Test(expected=NumberFormatException.class)
     public void testInvalidProxyPort() {
-        new AWSClientFactory("keys", "", "", "port", "", "", REGION, build);
+        new AWSClientFactory("keys", "", "", "port", "", "", "", REGION, build);
     }
 
     @Test
     public void testInvalidCredsOption() {
         try {
-            new AWSClientFactory("bad", "", "", "", "", "", REGION, build);
+            new AWSClientFactory("bad", "", "", "", "", "", "", REGION, build);
         } catch (InvalidInputException e) {
             assert(e.getMessage().contains(Validation.invalidCredTypeError));
         }
@@ -106,7 +109,7 @@ public class AWSClientFactoryTest {
 
     @Test
     public void testSpecifyCreds() {
-        AWSClientFactory awsClientFactory = new AWSClientFactory("keys", "", proxyHost, proxyPort, "a", "s", REGION, build);
+        AWSClientFactory awsClientFactory = new AWSClientFactory("keys", "", proxyHost, proxyPort, "a", "s", "t", REGION, build);
         assert(awsClientFactory.getProxyHost().equals(proxyHost));
         assert(awsClientFactory.getProxyPort().equals(Validation.parseInt(proxyPort)));
 
@@ -114,7 +117,7 @@ public class AWSClientFactoryTest {
 
     @Test
     public void testDefaultCreds() {
-        AWSClientFactory awsClientFactory = new AWSClientFactory("keys", "", proxyHost, proxyPort, "", "", REGION, build);
+        AWSClientFactory awsClientFactory = new AWSClientFactory("keys", "", proxyHost, proxyPort, "", "", "", REGION, build);
         assert(awsClientFactory.getProxyHost().equals(proxyHost));
         assert(awsClientFactory.getProxyPort().equals(Validation.parseInt(proxyPort)));
     }
@@ -124,7 +127,7 @@ public class AWSClientFactoryTest {
     @Test
     public void testNullCredsId() {
         try {
-            new AWSClientFactory("jenkins", null, "", "", "", "", REGION, build);
+            new AWSClientFactory("jenkins", null, "", "", "", "", "", REGION, build);
         } catch (InvalidInputException e) {
             assert(e.getMessage().contains(Validation.invalidCredentialsIdError));
         }
@@ -133,7 +136,7 @@ public class AWSClientFactoryTest {
     @Test
     public void testEmptyCredsId() {
         try {
-            new AWSClientFactory("jenkins", "", "", "", "", "", REGION, build);
+            new AWSClientFactory("jenkins", "", "", "", "", "", "", REGION, build);
         } catch (InvalidInputException e) {
             assert(e.getMessage().contains(Validation.invalidCredentialsIdError));
         }
@@ -142,7 +145,7 @@ public class AWSClientFactoryTest {
     @Test
     public void testJenkinsCreds() {
         String credentialsId = "id";
-        AWSClientFactory awsClientFactory = new AWSClientFactory("jenkins", credentialsId, "", "", "", "", REGION, build);
+        AWSClientFactory awsClientFactory = new AWSClientFactory("jenkins", credentialsId, "", "", "", "", "", REGION, build);
 
         assert(awsClientFactory.getProxyHost().equals(proxyHost));
         assert(awsClientFactory.getProxyPort().equals(Validation.parseInt(proxyPort)));
@@ -178,7 +181,7 @@ public class AWSClientFactoryTest {
         when(mockProject.getParent()).thenReturn(mockFolderItem);
         when(mockFolderItem.getFullName()).thenReturn(folder);
 
-        AWSClientFactory awsClientFactory = new AWSClientFactory("jenkins", credentialsId, "", "", "", "", REGION, build);
+        AWSClientFactory awsClientFactory = new AWSClientFactory("jenkins", credentialsId, "", "", "", "", "", REGION, build);
 
         assert(awsClientFactory.getProxyHost().equals(proxyHost));
         assert(awsClientFactory.getProxyPort().equals(Validation.parseInt(proxyPort)));
@@ -209,7 +212,7 @@ public class AWSClientFactoryTest {
         when(mockFolder.getFullName()).thenReturn(folder);
 
         try {
-            new AWSClientFactory("jenkins", credentialsId, "", "", "", "", REGION, build);
+            new AWSClientFactory("jenkins", credentialsId, "", "", "", "", "", REGION, build);
         } catch (InvalidInputException e) {
             assert(e.getMessage().contains(Validation.invalidCredentialsIdError));
             throw e;

--- a/src/test/java/CodeBuilderPerformTest.java
+++ b/src/test/java/CodeBuilderPerformTest.java
@@ -49,7 +49,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     public void testConfigAllNull() throws Exception {
         setUpBuildEnvironment();
         CodeBuilder test = new CodeBuilder(null, null, null, null, null,
-                null, null, null, null, null,
+                null, null, null, null, null, null,
                 null, null, null, null, null,
                 null, null, null, null, null, null, null);
 
@@ -65,7 +65,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     public void testConfigAllNullPipeline() throws Exception {
         setUpBuildEnvironment();
         CodeBuilder test = new CodeBuilder(null, null, null, null, null,
-                null, null, null, null, null,
+                null, null,null, null, null, null,
                 null, null, null, null, null, null,
                 null, null, null, null, null, null);
 
@@ -82,7 +82,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     public void testConfigAllBlank() throws Exception {
         setUpBuildEnvironment();
         CodeBuilder test = new CodeBuilder("", "", "", "", "",
-                "", "", "", "", "", "", "", "",
+                "", "", "", "", "", "", "", "", "",
                 "","","","","",     "", "", "", "");
 
         ArgumentCaptor<Result> savedResult = ArgumentCaptor.forClass(Result.class);
@@ -97,7 +97,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     public void testConfigAllBlankPipeline() throws Exception {
         setUpBuildEnvironment();
         CodeBuilder test = new CodeBuilder("", "", "", "", "",
-                "", "", "", "", "", "", "", "",
+                "", "", "","", "", "", "", "", "",
                 "","","","","",     "", "", "", "");
 
         test.setIsPipelineBuild(true);
@@ -112,7 +112,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     @Test
     public void testNoProjectName() throws Exception {
         setUpBuildEnvironment();
-        CodeBuilder test = new CodeBuilder("keys", "","", "", "", "",
+        CodeBuilder test = new CodeBuilder("keys", "","", "", "", "","",
                 "us-east-1", "", "", "", SourceControlType.ProjectSource.toString(),
                 "", "", "", "", "", "",
                 "","", "", "", "");
@@ -130,7 +130,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     @Test
     public void testNoProjectNamePipeline() throws Exception {
         setUpBuildEnvironment();
-        CodeBuilder test = new CodeBuilder("keys", "","", "", "", "",
+        CodeBuilder test = new CodeBuilder("keys", "","", "", "", "","",
                 "us-east-1", "", "", "", SourceControlType.ProjectSource.toString(),
                 "", "", "", "", "", "",
                 "","", "", "", "");
@@ -150,7 +150,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     @Test
     public void testNoSourceType() throws Exception {
         setUpBuildEnvironment();
-        CodeBuilder test = new CodeBuilder("keys", "","", "", "", "",
+        CodeBuilder test = new CodeBuilder("keys", "","", "", "", "","",
                 "us-east-1", "project", "", "", "",
                 "", "", "", "", "", "",
                 "","", "", "", "");
@@ -169,7 +169,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
     @Test
     public void testNoSourceTypePipeline() throws Exception {
         setUpBuildEnvironment();
-        CodeBuilder test = new CodeBuilder("keys", "","", "", "", "",
+        CodeBuilder test = new CodeBuilder("keys", "","", "", "", "","",
                 "us-east-1", "project", "", "", "",
                 "", "", "", "", "", "",
                 "","", "", "", "");
@@ -288,7 +288,7 @@ public class CodeBuilderPerformTest extends CodeBuilderTest {
         envVars.put("foo2", "bar2");
         envVars.put("foo3", "bar3");
 
-        CodeBuilder cb = new CodeBuilder("keys", "id123","host", "60", "a", "s",
+        CodeBuilder cb = new CodeBuilder("keys", "id123","host", "60", "a", "s", "",
                 "us-east-1", "$foo", "$foo2-$foo3", "", SourceControlType.ProjectSource.toString(), "1",
                 ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "",
                 "","[{k, v}]", "", "buildspec.yml", "5");

--- a/src/test/java/CodeBuilderTest.java
+++ b/src/test/java/CodeBuilderTest.java
@@ -73,7 +73,7 @@ public class CodeBuilderTest {
 
     //creates a CodeBuilder with mock parameters that reflect a typical use case.
     protected CodeBuilder createDefaultCodeBuilder() {
-        CodeBuilder cb = new CodeBuilder("keys", "id123","host", "60", "a", "s",
+        CodeBuilder cb = new CodeBuilder("keys", "id123","host", "60", "a", "s","",
                 "us-east-1", "existingProject", "sourceVersion", "", SourceControlType.ProjectSource.toString(),
                 "1", ArtifactsType.NO_ARTIFACTS.toString(), "", "", "", "",
                 "","[{k, v}]", "[{k, p}]", "buildspec.yml", "5");


### PR DESCRIPTION
Hey guys,

We need to pass assumed role credentials to the codebuild plugin so we could use codebuild together with `withAWS` (or any other assumed credentials) .  The following PR adds a new property `awsSessionToken` required to use credentials from `assumeRole`. I deliberately did not add it to the `jelly` since I reckon it's pointless to provide the field for a  temporary value.

The usage example 

```
withAWS(region:"us-west-2", role:"other-role", roleAccount:"0123456789") {
  codeBuildResult = awsCodeBuild 
    projectName: "hello-world",
    region: "us-west-2",
    sourceControlType: "project",
    credentialsType: "keys",
    awsAccessKey: env.AWS_ACCESS_KEY_ID,
    awsSecretKey: env.AWS_SECRET_ACCESS_KEY,
    awsSessionToken: env.AWS_SESSION_TOKEN
}
```