### PR TITLE
Allow changing parameters for polling CodeBuild result

### DIFF
--- a/src/main/resources/CodeBuilder/global.jelly
+++ b/src/main/resources/CodeBuilder/global.jelly
@@ -13,8 +13,15 @@
   ~
   -->
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-  <!--
-    This Jelly script is used to produce the global configuration option.
-  -->
-
+  <f:section title="${%AWS CodeBuild plugin}">
+    <f:entry title="${%Minimum interval for polling in milliseconds}" field="minSleepTime">
+      <f:number clazz="positive-number" default="2500"/>
+    </f:entry>
+    <f:entry title="${%Maximum interval for polling in milliseconds}" field="maxSleepTime">
+      <f:number default="60000"/>
+    </f:entry>
+    <f:entry title="${%Jitter for polling in milliseconds}" field="sleepJitter">
+      <f:number clazz="positive-number" default="5000"/>
+    </f:entry>
+  </f:section>
 </j:jelly>

--- a/src/test/java/CodeBuilderTest.java
+++ b/src/test/java/CodeBuilderTest.java
@@ -27,6 +27,8 @@ import hudson.model.TaskListener;
 import hudson.util.Secret;
 import org.jenkinsci.plugins.workflow.steps.StepContext;
 import org.junit.Before;
+import org.junit.Rule;
+import org.jvnet.hudson.test.JenkinsRule;
 import org.mockito.Mock;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
@@ -78,6 +80,9 @@ public class CodeBuilderTest {
 
     //mock console log
     protected ByteArrayOutputStream log;
+
+    @Rule
+    public JenkinsRule j = new JenkinsRule();
 
     //creates a CodeBuilder with mock parameters that reflect a typical use case.
     protected CodeBuilder createDefaultCodeBuilder() {


### PR DESCRIPTION
In our use-case, the default sleep time for polling CodeBuild result is
too long. I'd like to change parameters for polling.