### PR TITLE
Keep empty directories in zip file

### DIFF
--- a/src/main/java/ZipSourceCallable.java
+++ b/src/main/java/ZipSourceCallable.java
@@ -97,31 +97,38 @@ public class ZipSourceCallable extends MasterToSlaveFileCallable<String> {
         byte[] buffer = new byte[1024];
         int bytesRead;
 
-        for (int i = 0; i < dirFiles.size(); i++) {
-            FilePath f = new FilePath(workspace, dirFiles.get(i).getRemote());
-            if (f.isDirectory()) {
-                zipSource(workspace, f.getRemote() + File.separator, out, prefixToTrim);
-            } else {
-                InputStream inputStream = f.read();
-                try {
-                    String path = trimPrefix(f.getRemote(), prefixToTrim);
+        if (dirFiles.isEmpty()) {
+            String path = trimPrefix(dir.getRemote(), prefixToTrim);
+            if (!path.isEmpty()) {
+                out.putNextEntry(new ZipEntry(path + "/"));
+            }
+        } else {
+            for (int i = 0; i < dirFiles.size(); i++) {
+                FilePath f = new FilePath(workspace, dirFiles.get(i).getRemote());
+                if (f.isDirectory()) {
+                    zipSource(workspace, f.getRemote() + File.separator, out, prefixToTrim);
+                } else {
+                    InputStream inputStream = f.read();
+                    try {
+                        String path = trimPrefix(f.getRemote(), prefixToTrim);
 
-                    if(path.startsWith(File.separator)) {
-                        path = path.substring(1, path.length());
+                        if(path.startsWith(File.separator)) {
+                            path = path.substring(1, path.length());
+                        }
+
+                        // Zip files created on the windows file system will not unzip
+                        // properly on unix systems. Without this change, no directory structure
+                        // is built when unzipping.
+                        path = path.replace(File.separator, "/");
+
+                        ZipEntry entry = new ZipEntry(path);
+                        out.putNextEntry(entry);
+                        while ((bytesRead = inputStream.read(buffer)) != -1) {
+                            out.write(buffer, 0, bytesRead);
+                        }
+                    } finally {
+                        inputStream.close();
                     }
-
-                    // Zip files created on the windows file system will not unzip
-                    // properly on unix systems. Without this change, no directory structure
-                    // is built when unzipping.
-                    path = path.replace(File.separator, "/");
-
-                    ZipEntry entry = new ZipEntry(path);
-                    out.putNextEntry(entry);
-                    while ((bytesRead = inputStream.read(buffer)) != -1) {
-                        out.write(buffer, 0, bytesRead);
-                    }
-                } finally {
-                    inputStream.close();
                 }
             }
         }

--- a/src/test/java/S3DataManagerTest.java
+++ b/src/test/java/S3DataManagerTest.java
@@ -287,10 +287,14 @@ public class S3DataManagerTest {
         unzipFolder.mkdir();
         ZipFile z = new ZipFile(zip.getPath());
         z.extractAll(unzipFolder.getPath());
-        assertTrue(unzipFolder.list().length == 1);
-        assertTrue(unzipFolder.list()[0].equals(buildSpecName));
+        assertEquals(2, unzipFolder.list().length);
+        assertEquals(buildSpecName, unzipFolder.list()[0]);
+        assertEquals("src", unzipFolder.list()[1]);
         File extractedBuildSpec = new File(unzipFolder.getPath() + "/" + buildSpecName);
-        assertTrue(FileUtils.readFileToString(extractedBuildSpec).equals(buildSpecContents));
+        assertEquals(buildSpecContents, FileUtils.readFileToString(extractedBuildSpec));
+        File srcDir = new File(unzipFolder.getPath() + "/src");
+        assertTrue(srcDir.isDirectory());
+        assertEquals(0, srcDir.list().length);
     }
 
     @Test


### PR DESCRIPTION
Suppose we have the following directory structure.

```
% tree .
.
├── README.md
├── src
│   └── Main.java
└── tmp

2 directories, 2 files
```

I expect that the zip file used by CodeBuild contains empty "tmp"
directory, but it isn't.
More realistic example is .git/refs directory. When git packs refs,
.git/refs directory becomes empty but git actually requires .git/refs
directory. I suddenly encountered the following git error in CodeBuild
when git automatically packed refs.

```
fatal: not a git repository (or any parent up to mount point /codebuild)
Stopping at filesystem boundary (GIT_DISCOVERY_ACROSS_FILESYSTEM not set)
```