### PR TITLE
Support of special characters in buildspec override

### DIFF
--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -181,7 +181,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
         this.serviceRoleOverride = Validation.sanitize(serviceRoleOverride);
         this.envVariables = Validation.sanitize(envVariables);
         this.envParameters = Validation.sanitize(envParameters);
-        this.buildSpecFile = decodeJSON(Validation.sanitize(buildSpecFile));
+        this.buildSpecFile = decodeJSON(Validation.sanitizeYAML(buildSpecFile));
         this.buildTimeoutOverride = Validation.sanitize(buildTimeoutOverride);
         this.insecureSslOverride = Validation.sanitize(insecureSslOverride);
         this.privilegedModeOverride = Validation.sanitize(privilegedModeOverride);

--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -181,7 +181,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
         this.serviceRoleOverride = Validation.sanitize(serviceRoleOverride);
         this.envVariables = Validation.sanitize(envVariables);
         this.envParameters = Validation.sanitize(envParameters);
-        this.buildSpecFile = Validation.sanitize(buildSpecFile);
+        this.buildSpecFile = decodeJSON(Validation.sanitize(buildSpecFile));
         this.buildTimeoutOverride = Validation.sanitize(buildTimeoutOverride);
         this.insecureSslOverride = Validation.sanitize(insecureSslOverride);
         this.privilegedModeOverride = Validation.sanitize(privilegedModeOverride);
@@ -234,7 +234,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
         serviceRoleOverride = Validation.sanitize(serviceRoleOverride);
         envVariables = Validation.sanitize(envVariables);
         envParameters = Validation.sanitize(envParameters);
-        buildSpecFile = Validation.sanitizeYAML(buildSpecFile);
+        buildSpecFile = decodeJSON(Validation.sanitize(buildSpecFile));
         buildTimeoutOverride = Validation.sanitize(buildTimeoutOverride);
         insecureSslOverride = Validation.sanitize(insecureSslOverride);
         privilegedModeOverride = Validation.sanitize(privilegedModeOverride);

--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -962,7 +962,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
     }
 
     public static String decodeJSON(String json) {
-        return json.replaceAll("&amp;quot;", "\"").replaceAll("&quot;", "\"").replaceAll("&amp;", "&").replaceAll("&gt;", ">").replaceAll("<","&lt;").replaceAll("''", "'");
+        return json.replaceAll("&amp;quot;", "\"").replaceAll("&quot;", "\"").replaceAll("&amp;", "&").replaceAll("&gt;", ">").replaceAll("&lt;","<").replaceAll("''", "'");
     }
 
     // Overridden for better type safety.

--- a/src/main/java/CodeBuilder.java
+++ b/src/main/java/CodeBuilder.java
@@ -962,7 +962,7 @@ public class CodeBuilder extends Builder implements SimpleBuildStep {
     }
 
     public static String decodeJSON(String json) {
-        return json.replaceAll("&amp;quot;", "\"").replaceAll("&quot;", "\"");
+        return json.replaceAll("&amp;quot;", "\"").replaceAll("&quot;", "\"").replaceAll("&amp;", "&").replaceAll("&gt;", ">").replaceAll("<","&lt;").replaceAll("''", "'");
     }
 
     // Overridden for better type safety.


### PR DESCRIPTION
Currently it is impossible use shell in buildspec override field due to fact that special charactes in this field are replaced by escapeSql(escapeHtml(s.trim())) 

This small fix has an intention to restore them back.